### PR TITLE
Update CI to manage IOC versions

### DIFF
--- a/.github/workflows/bl_buiild.yml
+++ b/.github/workflows/bl_buiild.yml
@@ -32,14 +32,14 @@ jobs:
           # tar up any config folders that require it
           ./tar_config_src.sh
 
+          # Update all chart dependencies.
+          for ioc in ${ioc_dirs}; do helm dependency update ${ioc}; done
+
           # only publish if this is a tagged release
           if [[ ${GITHUB_REF} = refs/tags/* ]] ; then
 
             TAG=${GITHUB_REF#refs/tags/}
             ioc_dirs=$(ls -d iocs/*/)
-
-            # Update all chart dependencies.
-            for ioc in ${ioc_dirs}; do helm dependency update ${ioc}; done
 
             # update the helm chart versions with the tag
             sed -e "s/^version: .*$/version: ${TAG}/g" -e "s/^appVersion: .*$/appVersion: ${TAG}/g" -i iocs/*/Chart.yaml

--- a/.github/workflows/bl_buiild.yml
+++ b/.github/workflows/bl_buiild.yml
@@ -1,4 +1,4 @@
-name:  Build and publish a beamline's ioc helm charts
+name: Build and publish a beamline's ioc helm charts
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
 env:
   HELM_VERSION_TO_INSTALL: 3.8.2 # version of HELM to install
   GHCR_ROOT: ghcr.io/epics-containers
+  CR_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build-and-push-helm-charts:
@@ -27,34 +28,18 @@ jobs:
 
       - name: push each ioc helm chart
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GHCR_ROOT }} --username ${{ github.repository_owner }} --password-stdin
-
           # tar up any config folders that require it
           ./tar_config_src.sh
 
-          # Update all chart dependencies.
-          for ioc in ${ioc_dirs}; do helm dependency update ${ioc}; done
-
-          # only publish if this is a tagged release
-          if [[ ${GITHUB_REF} = refs/tags/* ]] ; then
-
-            TAG=${GITHUB_REF#refs/tags/}
-            ioc_dirs=$(ls -d iocs/*/)
-
-            # update the helm chart versions with the tag
-            sed -e "s/^version: .*$/version: ${TAG}/g" -e "s/^appVersion: .*$/appVersion: ${TAG}/g" -i iocs/*/Chart.yaml
-
-            # push all ioc chart packages to the registry
-            for ioc in ${ioc_dirs}
-            do
-                for THIS_TAG in latest ${TAG}
-                do
-                    URL="${GHCR_ROOT}/$(basename $ioc):${THIS_TAG}"
-                    echo saving ${ioc} to "${URL}" ...
-                    helm chart save ${ioc} "${URL}"
-                    echo push to "${URL}" ...
-                    helm chart push "${URL}"
-                done
-            done
-
+          # helm tags must be SemVar. Use 0.0.0-b0 for testing the latest non-tagged build
+          if [ "${GITHUB_REF_TYPE}" == "tag" ] ; then
+            TAG=${GITHUB_REF_NAME}
+          else
+            TAG="0.0.0-b0"
           fi
+
+          # All IOCS that have changes since last pushed to the helm registry
+          # will have version ${TAG} pushed 
+          for ioc_root in $(ls -d iocs/*/) ; do
+            ./helm-push.sh ${ioc_root} ${TAG}
+          done

--- a/helm-push.sh
+++ b/helm-push.sh
@@ -16,43 +16,48 @@ fi
 
 # Helm Registry in GHCR
 HELM_REPO=ghcr.io/epics-containers
-HELM_OCI=oci://${HELM_REPO}
 
 # extract name from the Chart.yaml
-NAME=$(awk '/^name:/{print $NF}' "${IOC_ROOT}/Chart.yaml")
-CHART=${HELM}/${NAME}
-CHART_OCI=${HELM_OCI}/${NAME}
+NAME=$(sed -n '/^name: */s///p' "${IOC_ROOT}/Chart.yaml")
+CHART=oci://${HELM_REPO}/${NAME}
 
 # Before calling this script: set CR_PAT to a github personal access token 
 # see https://github.com/settings/tokens
 echo $CR_PAT | helm registry login -u USERNAME --password-stdin $HELM_REPO
 
-echo "deploying ${IOC_ROOT} to helm repo as version ${TAG}"
+echo "Verifying deploy of ${IOC_ROOT} to helm repo as version ${TAG} ..."
 helm package "${IOC_ROOT}" -u --app-version ${TAG} --version ${TAG}
 PACKAGE=$(realpath ${NAME}-${TAG}.tgz)
 
-# determine if this IOC has changed since latest helm chart push
-TMPDIR=$(mktemp -d)
-cd $TMPDIR
-helm pull ${CHART_OCI} > out.txt
-LATEST_VERSION=$(sed -n '/^Pulled/s=.*:==p' out.txt)
-echo latest chart: $LATEST_VERSION
-mkdir latest_ioc this_ioc
-tar -xf *tgz -C latest_ioc
-# repackage the new IOC with same version as above for direct comparison
-# (packaging reformats the Chart.yaml file so this is the best approach)
-helm package "${IOC_ROOT}" -u --app-version ${LATEST_VERSION} --version ${LATEST_VERSION}
-tar -xf *tgz -C this_ioc
-echo comparing $(realpath latest) $(realpath this) 
-if diff -r latest_ioc this_ioc &> diff.out ; then 
-    MATCH=YES ; else MATCH=NO
-fi
-cd -
-rm -r $TMPDIR
+# Temp dir for testing if the helm chart has changed
+TMPDIR=$(mktemp -d); cd ${TMPDIR}
 
-if [ "$MATCH" == "NO" ] ; then    
-    helm push "${PACKAGE}" ${HELM_OCI}
-else 
-    echo "not pushing unchanged IOC"
+# extract the latest version to a temporary folder
+helm pull ${CHART} > out.txt
+LATEST_VERSION=$(sed -n '/^Pulled:/s/.*://p' out.txt)
+echo "latest version of ${CHART} is ${LATEST_VERSION}"
+mkdir latest_ioc this_ioc
+tar -xf *tgz -C latest_ioc &> tar1.out
+
+# repackage the new IOC with same version as above for direct comparison
+# (packaging reformats the Chart.yaml file so this is the simplest approach)
+helm package "${IOC_ROOT}" --app-version ${LATEST_VERSION} --version ${LATEST_VERSION}
+tar -xf *tgz -C this_ioc &> tar2.out
+
+# compare the packages and push the new package if it has changed
+if diff -r latest_ioc this_ioc &> diff.out ; then 
+    echo "not pushing unchanged IOC ${CHART} version ${LATEST_VERSION}"   
+else
+    echo "pushing ${CHART} version ${TAG}"   
+    helm push "${PACKAGE}" oci://${HELM_REPO}
 fi
-rm "${PACKAGE}"
+
+cat diff.out
+
+# clean up
+if [ -z ${HELM_PUSH_DEBUG} ] ; then
+    rm "${PACKAGE}"
+    rm -r ${TMPDIR}
+else
+    echo "helm-push.sh comparison output is in ${TMPDIR}"
+fi

--- a/helm-push.sh
+++ b/helm-push.sh
@@ -6,7 +6,7 @@
 # the main branch (this makes the source for the chart discoverable)
 set -e
 
-IOC_ROOT="${1}"
+IOC_ROOT="$(realpath ${1})"
 # determine the tag to use based on date or argument 2
 TAG=${2:-$(date +%Y.%-m.%-d-%-H%M)}
 
@@ -14,19 +14,45 @@ if [ -z "${IOC_ROOT}" ] ; then
   echo "usage: helm-push.sh <ioc root folder> <semvar tag>"
 fi
 
-# Helm Registry in diamond GHCR
+# Helm Registry in GHCR
 HELM_REPO=ghcr.io/epics-containers
+HELM_OCI=oci://${HELM_REPO}
 
 # extract name from the Chart.yaml
 NAME=$(awk '/^name:/{print $NF}' "${IOC_ROOT}/Chart.yaml")
+CHART=${HELM}/${NAME}
+CHART_OCI=${HELM_OCI}/${NAME}
 
-# must set CR_PAT to a github personal access token 
+# Before calling this script: set CR_PAT to a github personal access token 
 # see https://github.com/settings/tokens
 echo $CR_PAT | helm registry login -u USERNAME --password-stdin $HELM_REPO
 
 echo "deploying ${IOC_ROOT} to helm repo as version ${TAG}"
 helm package "${IOC_ROOT}" -u --app-version ${TAG} --version ${TAG}
-package=${NAME}-${TAG}.tgz
-          
-helm push "${package}" oci://${HELM_REPO}
-rm "${package}"
+PACKAGE=$(realpath ${NAME}-${TAG}.tgz)
+
+# determine if this IOC has changed since latest helm chart push
+TMPDIR=$(mktemp -d)
+cd $TMPDIR
+helm pull ${CHART_OCI} > out.txt
+LATEST_VERSION=$(sed -n '/^Pulled/s=.*:==p' out.txt)
+echo latest chart: $LATEST_VERSION
+mkdir latest_ioc this_ioc
+tar -xf *tgz -C latest_ioc
+# repackage the new IOC with same version as above for direct comparison
+# (packaging reformats the Chart.yaml file so this is the best approach)
+helm package "${IOC_ROOT}" -u --app-version ${LATEST_VERSION} --version ${LATEST_VERSION}
+tar -xf *tgz -C this_ioc
+echo comparing $(realpath latest) $(realpath this) 
+if diff -r latest_ioc this_ioc &> diff.out ; then 
+    MATCH=YES ; else MATCH=NO
+fi
+cd -
+rm -r $TMPDIR
+
+if [ "$MATCH" == "NO" ] ; then    
+    helm push "${PACKAGE}" ${HELM_OCI}
+else 
+    echo "not pushing unchanged IOC"
+fi
+rm "${PACKAGE}"

--- a/iocs/bl45p-ea-ioc-02/values.yaml
+++ b/iocs/bl45p-ea-ioc-02/values.yaml
@@ -1,15 +1,2 @@
-beamline: bl45p
-namespace: bl45p
+name: bl45p-ea-ioc-02
 base_image: ghcr.io/epics-containers/ioc-adpandablocks:4.14r1.0.run
-
-# root folder of generic ioc source - not expected to change
-iocFolder: /epics/ioc
-
-# useAffinity - only run on nodes with label beamline:bl45p
-useAffinity: true
-# use default resource limits
-memory:
-cpu:
-
-# when autosave is true: create PVC and mount at /autosave
-autosave: true

--- a/iocs/bl45p-mo-ioc-01/Chart.yaml
+++ b/iocs/bl45p-mo-ioc-01/Chart.yaml
@@ -6,8 +6,8 @@ description: |
 type: application
 
 # chart and app version - these are updated automatically by CI
-version: 2021.2.0
-appVersion: 2021.2.0
+version: 0.0.0-b0
+appVersion: 0.0.0-b0
 
 dependencies:
   - name: bl45p-chart

--- a/iocs/bl45p-mo-ioc-01/config/start.sh
+++ b/iocs/bl45p-mo-ioc-01/config/start.sh
@@ -23,7 +23,7 @@ boot=${config_dir}/ioc.boot
 
 # Update the boot script to work in the directory it resides in
 # using msi MACRO substitution.
-# Output to /tmp for guarenteed writability
+# Output to /tmp for guarenteed writability.
 msi -MTOP=${TOP},THIS_DIR=${config_dir} ${boot} > /tmp/ioc.boot
 
 exec ${IOC}/bin/linux-x86_64/ioc /tmp/ioc.boot

--- a/iocs/bl45p-mo-ioc-01/config/start.sh
+++ b/iocs/bl45p-mo-ioc-01/config/start.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-#
+########################################
 # generic kubernetes IOC startup script
-#
+########################################
 
 this_dir=$(realpath $(dirname $0))
 TOP=$(realpath ${this_dir}/..)


### PR DESCRIPTION
CI will now only deploy IOCs to the Helm Registry if there are changes to the IOC with respect to the the current highest version tag in already pushed.
