### PR TITLE
Add daq-blueapi service

### DIFF
--- a/services/daq-blueapi/Chart.yaml
+++ b/services/daq-blueapi/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: daq-blueapi
+description: blueapi
+
+version: 0.4.0
+
+# When we deploy with the edge-containers-cli we override this on the command line.
+# Direct deployment with Helm will use the default beta value.
+appVersion: 0.0.1b1
+
+type: application
+
+dependencies:
+  - name: blueapi
+    version: "0.4.0"
+    repository: "oci://ghcr.io/diamondlightsource/charts"

--- a/services/daq-blueapi/README.md
+++ b/services/daq-blueapi/README.md
@@ -1,0 +1,14 @@
+daq-blueapi Helm Chart
+=====================
+
+Installs a blueapi instance.
+
+Deploy this chart to the cluster by setting up your cluster namespace connection
+using environment.sh and then executing the following commands:
+
+```bash
+# lists the latest versions of all services
+ec list
+# deploy daq-blueapi with specified version
+ec deploy daq-blueapi VERSION
+```

--- a/services/daq-blueapi/values.yaml
+++ b/services/daq-blueapi/values.yaml
@@ -1,0 +1,55 @@
+blueapi:
+  hostNetwork: true
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+    requests:
+      cpu: 500m
+      memory: 100Mi
+  nodeSelector:
+    kubernetes.io/hostname: p45-control.diamond.ac.uk
+  tolerations:
+    - key: nodetype
+      operator: Equal
+      value: test-rig
+      effect: NoSchedule
+    - key: beamline
+      operator: Equal
+      value: bl45p
+      effect: NoSchedule
+  ingress:
+    create: false
+#    host: p45-blueapi.diamond.ac.uk  # TODO: Get DNS entry created
+  extraEnvVars: |
+    - name: SCRATCH_AREA
+      value: {{ .Values.scratch.containerPath }}
+    - name: RABBITMQ_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rabbitmq-password
+          key: rabbitmq-password
+  worker:
+    env:
+      sources:
+        - kind: dodal
+          module: dodal.beamlines.p45
+        # TODO: Make p45 plans repository
+        - kind: planFunctions
+          module: dls_bluesky_core.plans
+        - kind: planFunctions
+          module: dls_bluesky_core.stubs
+      data_writing:
+        visit_service_url: http://p45-control.diamond.ac.uk:8088/api
+        visit_directory: /dls/p45/data/2024/cm37283-2
+        group_name: p45
+      events: 
+        broadcast_status_events: False
+    stomp:
+      auth:
+        username: p45
+        passcode: ${RABBITMQ_PASSWORD}
+      host: p45-rabbitmq-daq.diamond.ac.uk
+  scratch:
+    hostPath: /dls_sw/p45/software/blueapi/scratch
+    containerPath: /dls_sw/p45/software/blueapi/scratch


### PR DESCRIPTION
The blueapi service wraps a bluesky run engine and exposes plans and devices via a REST api.

Moved from previous home in umbrella daq-deployments repository.